### PR TITLE
feat(stellar): cover create_account, path_payment, and effect-driven ops

### DIFF
--- a/src/templates/token-transfers/stellar.ts
+++ b/src/templates/token-transfers/stellar.ts
@@ -3,16 +3,118 @@ import { blockToVM } from '../../utils/block-to-vm';
 import { NetworkTransfer } from './types';
 import type { StellarLedger } from '../../types/beats/stellar';
 
+type StellarEffect = {
+  type: string;
+  account?: string;
+  contract?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  asset?: string;
+};
+
+// Stellar amounts are stringified decimals with 7 fractional digits ("12.3456789"),
+// but jiti expresses everything in stroops (smallest unit). Stripping the dot is
+// equivalent to multiplying by 10^7.
+const toStroops = (s: string) => BigInt(s.replace('.', ''));
+
+const effectAsset = (e: StellarEffect): { token: string | null; tokenType: 'NATIVE' | 'TOKEN' } => {
+  if (e.asset_type === 'native') return { token: null, tokenType: 'NATIVE' };
+  if (e.asset_issuer) return { token: e.asset_issuer, tokenType: 'TOKEN' };
+  // contract_* effects expose `asset` as a single string ("CODE:ISSUER" or "native").
+  if (e.asset && e.asset !== 'native') {
+    const [, issuer] = e.asset.split(':');
+    return { token: issuer ?? e.asset, tokenType: 'TOKEN' };
+  }
+  return { token: null, tokenType: 'NATIVE' };
+};
+
+const sameAsset = (a: StellarEffect, b: StellarEffect) =>
+  a.asset_type === b.asset_type &&
+  a.asset_code === b.asset_code &&
+  a.asset_issuer === b.asset_issuer &&
+  a.asset === b.asset;
+
+// Pair account_debited/account_credited effects within a single op into transfers.
+// Used for ops where amount/asset isn't reliably on the op body (offer fills,
+// account_merge, claim_claimable_balance, liquidity_pool_*, invoke_host_function).
+// Unpaired sides become one-sided transfers (e.g. claim_claimable_balance has no
+// debit because the source is a protocol-managed escrow).
+function effectsToTransfers(
+  typedTx: StellarLedger['transactions'][number],
+  op: StellarLedger['transactions'][number]['operations'][number] & { effects?: StellarEffect[] },
+  typedBlock: StellarLedger
+): NetworkTransfer[] {
+  const transfers: NetworkTransfer[] = [];
+  const effects = (op.effects || []).filter((e) => typeof e.amount === 'string');
+  const debits = effects.filter((e) => e.type === 'account_debited' || e.type === 'contract_debited');
+  const credits = effects.filter((e) => e.type === 'account_credited' || e.type === 'contract_credited');
+
+  const baseFields = {
+    blockNumber: typedBlock.sequence,
+    memo: typedTx.memo,
+    timestamp: typedTx.created_at,
+    transactionGasFee: BigInt(typedTx.fee_charged),
+    transactionHash: typedTx.hash,
+  };
+
+  const usedCredit = new Set<number>();
+  for (const d of debits) {
+    if (!d.amount) continue;
+    const idx = credits.findIndex((c, i) => !usedCredit.has(i) && sameAsset(d, c) && c.amount === d.amount);
+    const { token, tokenType } = effectAsset(d);
+    if (idx !== -1) {
+      const c = credits[idx];
+      usedCredit.add(idx);
+      transfers.push({
+        ...baseFields,
+        amount: toStroops(d.amount),
+        from: d.account || d.contract || null,
+        to: c.account || c.contract || null,
+        token,
+        tokenType,
+      });
+    } else {
+      transfers.push({
+        ...baseFields,
+        amount: toStroops(d.amount),
+        from: d.account || d.contract || null,
+        to: null,
+        token,
+        tokenType,
+      });
+    }
+  }
+
+  for (let i = 0; i < credits.length; i++) {
+    if (usedCredit.has(i)) continue;
+    const c = credits[i];
+    if (!c.amount) continue;
+    const { token, tokenType } = effectAsset(c);
+    transfers.push({
+      ...baseFields,
+      amount: toStroops(c.amount),
+      from: null,
+      to: c.account || c.contract || null,
+      token,
+      tokenType,
+    });
+  }
+
+  return transfers;
+}
+
 export const StellarTokenTransfers: SubTemplate = {
   match: (block) => blockToVM(block) === 'STELLAR',
 
   transform(block) {
-    let transfers: NetworkTransfer[] = [];
+    const transfers: NetworkTransfer[] = [];
     const typedBlock = block as unknown as StellarLedger;
 
     for (const typedTx of typedBlock.transactions || []) {
       // Failed txs still burn fee_charged — emit a fee transfer (to: null) so callers
-      // can account for the gas, but skip the payment ops that never actually moved funds.
+      // can account for the gas, but skip the ops that never actually moved funds.
       if (!typedTx.successful) {
         transfers.push({
           amount: BigInt(typedTx.fee_charged),
@@ -28,20 +130,62 @@ export const StellarTokenTransfers: SubTemplate = {
         });
         continue;
       }
+
       for (const op of typedTx.operations) {
+        const baseFields = {
+          blockNumber: typedBlock.sequence,
+          memo: typedTx.memo,
+          timestamp: typedTx.created_at,
+          transactionGasFee: BigInt(typedTx.fee_charged),
+          transactionHash: typedTx.hash,
+        };
+
         if (op.type === 'payment') {
           transfers.push({
-            amount: BigInt(op.amount.replace('.', '')),
-            blockNumber: typedBlock.sequence,
+            ...baseFields,
+            amount: toStroops(op.amount),
             from: op.from,
-            memo: typedTx.memo,
-            timestamp: typedTx.created_at,
             to: op.to,
             token: op.asset_type === 'native' ? null : op.asset_issuer,
             tokenType: op.asset_type === 'native' ? 'NATIVE' : 'TOKEN',
-            transactionGasFee: BigInt(typedTx.fee_charged),
-            transactionHash: typedTx.hash,
           });
+        } else if (op.type === 'create_account') {
+          // create_account funds a new account with native XLM via starting_balance —
+          // economically a native payment from funder → account, but a different op
+          // type because it also creates the destination ledger entry.
+          transfers.push({
+            ...baseFields,
+            amount: toStroops(op.starting_balance),
+            from: op.funder,
+            to: op.account,
+            token: null,
+            tokenType: 'NATIVE',
+          });
+        } else if (op.type === 'path_payment_strict_send' || op.type === 'path_payment_strict_receive') {
+          // Path payments swap source_asset → asset along a DEX path. Both legs are
+          // emitted as separate transfers (different assets, different amounts) so the
+          // sender debit and receiver credit are both visible from op fields alone.
+          transfers.push({
+            ...baseFields,
+            amount: toStroops(op.source_amount),
+            from: op.from,
+            to: op.to,
+            token: op.source_asset_type === 'native' ? null : op.source_asset_issuer,
+            tokenType: op.source_asset_type === 'native' ? 'NATIVE' : 'TOKEN',
+          });
+          transfers.push({
+            ...baseFields,
+            amount: toStroops(op.amount),
+            from: op.from,
+            to: op.to,
+            token: op.asset_type === 'native' ? null : op.asset_issuer,
+            tokenType: op.asset_type === 'native' ? 'NATIVE' : 'TOKEN',
+          });
+        } else {
+          // Everything else — manage_*_offer fills, account_merge, claim_claimable_balance,
+          // liquidity_pool_*, invoke_host_function (Soroban) — surfaces fund movements
+          // only via Horizon effects. Requires oscar to attach `op.effects` (#38).
+          transfers.push(...effectsToTransfers(typedTx, op, typedBlock));
         }
       }
     }
@@ -50,36 +194,85 @@ export const StellarTokenTransfers: SubTemplate = {
   },
 
   tests: [
+    // Single-op token payment: source wallet → dest wallet, USDC asset.
     {
       params: {
         network: 'STELLAR',
-        walletAddress: 'GC5HUFIKZBK5XRNOBPXR4PBR3PWR26GP5UFRKSCOOOIENYVSF3NMA23U',
+        transactionHash: 'e08e8dd92bde178c554146475cafdf00cef8a8874541b1bb568760b5bd33c6e6',
       },
-      payload: 'https://jiti.indexing.co/networks/stellar/59592273',
+      payload: 'https://jiti.indexing.co/networks/stellar/62312535',
       output: [
         {
-          amount: 651200000n,
-          blockNumber: 59592273,
-          from: 'GC5HUFIKZBK5XRNOBPXR4PBR3PWR26GP5UFRKSCOOOIENYVSF3NMA23U',
-          memo: '315004227',
-          timestamp: '2025-10-28T17:24:17Z',
-          to: 'GABFQIK63R2NETJM7T673EAMZN4RJLLGP3OFUEJU5SZVTGWUKULZJNL6',
+          amount: 100000000n,
+          blockNumber: 62312535,
+          from: 'GAUA7XL5K54CC2DDGP77FJ2YBHRJLT36CPZDXWPM6MP7MANOGG77PNJU',
+          memo: undefined,
+          timestamp: '2026-04-27T16:14:30Z',
+          to: 'GBTPFDSY7NFLFXAXXU725NUB2CXYM57RXG4ATYWBTK7RB57DFFNIU7RH',
           token: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
           tokenType: 'TOKEN',
           transactionGasFee: 200n,
-          transactionHash: 'a0e5f0cbc64a13816db1d8428c4e2f849ed9ec475b80d4cbd23a8119b1b1c010',
+          transactionHash: 'e08e8dd92bde178c554146475cafdf00cef8a8874541b1bb568760b5bd33c6e6',
+        },
+      ],
+    },
+    // path_payment_strict_send swaps source_asset → asset along a DEX path. Both legs
+    // are emitted as separate transfers so the sender debit and receiver credit are
+    // visible. Self-swap here (source==dest) but logic handles distinct accounts the
+    // same way.
+    {
+      params: {
+        network: 'STELLAR',
+        transactionHash: 'f036756ae1cbf61d8e43af39b24b991b59c3684fc030de42f5d8fc2c96a672eb',
+      },
+      payload: 'https://jiti.indexing.co/networks/stellar/62312422',
+      output: [
+        {
+          amount: 1000000n,
+          blockNumber: 62312422,
+          from: 'GCY7AY7OOO2XKZUCKLOZL3MJ62DW5UNL3ISFWDEDEEJM7JFGYZEUS55Z',
+          memo: undefined,
+          timestamp: '2026-04-27T16:03:47Z',
+          to: 'GCY7AY7OOO2XKZUCKLOZL3MJ62DW5UNL3ISFWDEDEEJM7JFGYZEUS55Z',
+          token: 'GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55',
+          tokenType: 'TOKEN',
+          transactionGasFee: 200n,
+          transactionHash: 'f036756ae1cbf61d8e43af39b24b991b59c3684fc030de42f5d8fc2c96a672eb',
         },
         {
-          amount: 4445100000n,
-          blockNumber: 59592273,
-          from: 'GAUA7XL5K54CC2DDGP77FJ2YBHRJLT36CPZDXWPM6MP7MANOGG77PNJU',
+          amount: 1000179n,
+          blockNumber: 62312422,
+          from: 'GCY7AY7OOO2XKZUCKLOZL3MJ62DW5UNL3ISFWDEDEEJM7JFGYZEUS55Z',
           memo: undefined,
-          timestamp: '2025-10-28T17:24:17Z',
-          to: 'GC5HUFIKZBK5XRNOBPXR4PBR3PWR26GP5UFRKSCOOOIENYVSF3NMA23U',
-          token: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
-          tokenType: 'TOKEN',
-          transactionGasFee: 300n,
-          transactionHash: 'c554aed41145304e03c0877c9de526cdcb8a8255c9bf156ff0dec202ab12e20d',
+          timestamp: '2026-04-27T16:03:47Z',
+          to: 'GCY7AY7OOO2XKZUCKLOZL3MJ62DW5UNL3ISFWDEDEEJM7JFGYZEUS55Z',
+          token: null,
+          tokenType: 'NATIVE',
+          transactionGasFee: 200n,
+          transactionHash: 'f036756ae1cbf61d8e43af39b24b991b59c3684fc030de42f5d8fc2c96a672eb',
+        },
+      ],
+    },
+    // create_account funds a new account with native XLM — emit it as a NATIVE
+    // transfer (funder → account) using starting_balance.
+    {
+      params: {
+        network: 'STELLAR',
+        transactionHash: 'a11add92603c4cab2396804f26acfe6fb9b0f938dc7dfa9f2ed017eb75ca039a',
+      },
+      payload: 'https://jiti.indexing.co/networks/stellar/62080113',
+      output: [
+        {
+          amount: 344880700n,
+          blockNumber: 62080113,
+          from: 'GDF4UGQSY6VHWN7T4XJEZ6WYJEREMZYLNYZ5CCKYVS3V3MNYIBMTB354',
+          memo: undefined,
+          timestamp: '2026-04-12T04:27:18Z',
+          to: 'GBJO6JIIPD4JEKDTKY4CKOSQZU3ETIKVWAWU56A46W72G377BGG4PS44',
+          token: null,
+          tokenType: 'NATIVE',
+          transactionGasFee: 100n,
+          transactionHash: 'a11add92603c4cab2396804f26acfe6fb9b0f938dc7dfa9f2ed017eb75ca039a',
         },
       ],
     },


### PR DESCRIPTION
## Origin

User reported [`https://jiti.indexing.co/presets/token-transfers/STELLAR?hash=a11add92...`](https://jiti.indexing.co/presets/token-transfers/STELLAR?hash=a11add92603c4cab2396804f26acfe6fb9b0f938dc7dfa9f2ed017eb75ca039a) returning empty `data` for a tx that visibly moved 34 XLM. Audit revealed the Stellar template only handled `payment` ops — every other op type silently dropped its transfers. Verified against a user-supplied CSV of 14 confirmed-successful Stellar txs: **all 14 are `create_account` ops** (the new-account funding pattern), and all returned empty pre-fix.

## Strategy

| Op type | Source of truth | Emitted |
|---|---|---|
| `payment` | op fields | 1 transfer (existing) |
| `create_account` | op fields (`funder` → `account`, `starting_balance`) | 1 transfer (NEW) |
| `path_payment_strict_send` / `path_payment_strict_receive` | op fields (both legs) | 2 transfers per op — source asset/amount + dest asset/amount (NEW) |
| `manage_*_offer` (when fills), `account_merge`, `claim_claimable_balance`, `liquidity_pool_*`, `invoke_host_function` | `op.effects` from Horizon | paired credit/debit → 2-sided transfers; unpaired → 1-sided (NEW) |
| failed tx | `fee_charged` | fee transfer (unchanged) |

The effects-driven path covers Soroban via `contract_credited`/`contract_debited` in addition to `account_credited`/`account_debited`. Pairing is by asset (type+code+issuer or string `asset`) AND amount within a single op — this correctly handles offer fills (matching credit/debit at same amount on different accounts) without merging unrelated movements.

## Dependency

Effects-driven paths require `op.effects` in the block payload, added in [oscar#38](https://github.com/indexing-co/oscar/pull/38) — already merged + deployed. Ops without effects (older cached blocks) gracefully no-op the effects branch.

## Validation

- All 4 inline tests pass (`payment`, `create_account`, `path_payment_strict_send`, failed-tx fee)
- All 14 user-reported `create_account` txs from the CSV now produce the expected single transfer (correct stroop amount, `from=funder`, `to=account`, `tokenType=NATIVE`)
- Existing fixture for ledger 59592273 (Oct 2025) replaced — that ledger fell out of Horizon retention and was returning `null`, so the test was silently broken. Replaced with a recent (Apr 2026) single-op token payment.
- Smoke-tested effects-driven path against ledger 62312424 (a 100-op `claim_claimable_balance` tx, dedupes to 61 distinct transfers): all transfers correctly emitted with `from=null` (escrow source), `to=claimant`, correct asset+amount.

## Known gap

Effects-driven code paths (claim_claimable_balance, account_merge, offer fills, liquidity_pool_*, Soroban) are not pinned in inline tests — the cleanest representative fixtures available are noisy (100-op claims, 9-op multi-payments, etc.). Follow-up PR to add minimal pinned tests for each as smaller fixtures appear in mainnet history.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] All 4 inline tests pass
- [x] All 14 CSV-reported create_account txs validated
- [x] Smoke-tested effects path on real claim_claimable_balance tx
- [ ] Confirm CI passes (auto version bump + npm publish on merge)
- [ ] Bump `@indexing/jiti` in oscar/indexer/nbd after publish