### PR TITLE
feat(ton): emit native + jetton transfers from a single in_msg pass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@cosmjs/proto-signing": "^0.33.0",
         "@cosmjs/stargate": "^0.33.0",
+        "@ton/core": "^0.63.1",
         "bs58": "^6.0.0",
         "isomorphic-fetch": "^3.0.0",
         "tronweb": "^6.0.4",
@@ -2666,6 +2667,37 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@ton/core": {
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.63.1.tgz",
+      "integrity": "sha512-hDWMjlKzc18W2E4OeV3hUP8ohRJNHPD4Wd1+AQJj8zshZyCRT0usrvnExgbNUTo/vntDqCGMzgYWbXxyaA+L4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@ton/crypto": ">=3.2.0"
+      }
+    },
+    "node_modules/@ton/crypto": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.3.0.tgz",
+      "integrity": "sha512-/A6CYGgA/H36OZ9BbTaGerKtzWp50rg67ZCH2oIjV1NcrBaCK9Z343M+CxedvM7Haf3f/Ee9EhxyeTp0GKMUpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ton/crypto-primitives": "2.1.0",
+        "jssha": "3.2.0",
+        "tweetnacl": "1.0.3"
+      }
+    },
+    "node_modules/@ton/crypto-primitives": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.1.0.tgz",
+      "integrity": "sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jssha": "3.2.0"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -4898,6 +4930,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/jssha": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.2.0.tgz",
+      "integrity": "sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6258,6 +6300,13 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@cosmjs/proto-signing": "^0.33.0",
     "@cosmjs/stargate": "^0.33.0",
+    "@ton/core": "^0.63.1",
     "bs58": "^6.0.0",
     "isomorphic-fetch": "^3.0.0",
     "tronweb": "^6.0.4",

--- a/src/templates/token-transfers/ton.ts
+++ b/src/templates/token-transfers/ton.ts
@@ -1,54 +1,121 @@
+import { Cell } from '@ton/core';
 import { SubTemplate } from '../../types';
 import { blockToVM } from '../../utils/block-to-vm';
 import { NetworkTransfer } from './types';
 import type { TonBlock } from '../../types/beats/ton';
 
+// TEP-74 jetton `internal_transfer` op-code. This is the message a recipient's
+// jetton wallet receives when it is credited, so it is the canonical signal of a
+// jetton deposit landing — and the only jetton message whose executing account
+// (`tx.address`) is the recipient jetton wallet itself.
+const JETTON_INTERNAL_TRANSFER_OP = 0x178d4519;
+
+type JettonInternalTransfer = {
+  amount: bigint;
+  from?: string;
+};
+
+// Decode a jetton `internal_transfer` message body (a base64-encoded BoC).
+// Returns null when the body is absent, is not a BoC, or carries a different
+// op-code (text comments, other jetton ops, arbitrary contract calls) — the
+// caller then falls back to the native path. Body layout (TEP-74):
+//   internal_transfer#0x178d4519 query_id:uint64 amount:(VarUInteger 16)
+//     from:MsgAddress response_address:MsgAddress ...
+function decodeJettonInternalTransfer(body: string | undefined): JettonInternalTransfer | null {
+  if (!body) {
+    return null;
+  }
+
+  try {
+    const slice = Cell.fromBoc(Buffer.from(body, 'base64'))[0].beginParse();
+    if (slice.loadUint(32) !== JETTON_INTERNAL_TRANSFER_OP) {
+      return null;
+    }
+
+    slice.loadUintBig(64); // query_id
+    const amount = slice.loadCoins();
+    // `from` is the sending owner, read best-effort: it can be addr_none on some
+    // mints/airdrops, and rare non-standard address encodings can throw. In
+    // either case keep the (valid) amount and let the caller fall back to the
+    // message source rather than dropping a real jetton transfer.
+    let from: string | undefined;
+    try {
+      const fromAddress = slice.loadMaybeAddress();
+      from = fromAddress ? fromAddress.toString({ urlSafe: true, bounceable: true, testOnly: false }) : undefined;
+    } catch {
+      from = undefined;
+    }
+
+    return { amount, from };
+  } catch {
+    return null;
+  }
+}
+
 export const TONTokenTransfers: SubTemplate = {
   match: (block) => blockToVM(block) === 'TON',
 
   transform(block) {
-    let transfers: NetworkTransfer[] = [];
+    const transfers: NetworkTransfer[] = [];
     const typedBlock = block as unknown as TonBlock;
-
     const blockNumber = typedBlock.seqno;
-    const blockTimestamp = new Date(typedBlock.shards?.[0]?.gen_utime * 1000).toISOString();
 
     for (const shard of typedBlock.shards || []) {
       for (const tx of shard.transactions || []) {
-        const transactionLT = tx.transaction_id.lt;
-        const transactionHash = tx.transaction_id.hash;
-        const transactionFee = BigInt(tx.fee || '0');
-
-        const inVal = BigInt(tx.in_msg?.value || '0');
-        if (inVal > 0n) {
-          transfers.push({
-            blockNumber,
-            from: tx.in_msg?.source?.account_address,
-            to: tx.address?.account_address,
-            amount: inVal,
-            token: 'TON',
-            tokenType: 'NATIVE',
-            timestamp: blockTimestamp,
-            transactionHash,
-            transactionGasFee: transactionFee,
-          });
+        const inMsg = tx.in_msg;
+        if (!inMsg) {
+          continue;
         }
 
-        for (const outMsg of tx.out_msgs || []) {
-          const outVal = BigInt(outMsg.value || '0');
-          if (outVal > 0n) {
-            transfers.push({
-              blockNumber,
-              from: outMsg.source?.account_address,
-              to: outMsg.destination?.account_address,
-              amount: outVal,
-              token: 'TON',
-              tokenType: 'NATIVE',
-              timestamp: blockTimestamp,
-              transactionHash,
-              transactionGasFee: transactionFee,
-            });
-          }
+        const transactionHash = tx.transaction_id?.hash;
+        const transactionGasFee = BigInt(tx.fee || '0');
+        // Per-transaction time. shards[0].gen_utime — the previous source — is
+        // wrong for any transaction outside the first shard and is undefined for
+        // empty shards (producing `Invalid Date`).
+        const timestamp = new Date((tx.utime || 0) * 1000).toISOString();
+        // The account this transaction executed on: the recipient account for a
+        // native transfer, or the recipient's jetton wallet for a jetton one
+        // (== in_msg.destination).
+        const to = tx.address?.account_address;
+
+        // Walk `in_msg` only: every transfer is recorded once, at the
+        // recipient's transaction, with `from` carried on the row so sender
+        // queries still match. Walking `out_msgs` too would double-emit each hop
+        // — the sender's and the recipient's transactions both fall in range.
+        const jetton = decodeJettonInternalTransfer(inMsg.msg_data?.body);
+        if (jetton) {
+          // Jetton and native value are mutually exclusive per message: a jetton
+          // `internal_transfer` also carries forwarded gas as `in_msg.value`, so
+          // emitting a native transfer here too would surface a phantom TON hop.
+          transfers.push({
+            blockNumber,
+            from: jetton.from || inMsg.source?.account_address,
+            to,
+            amount: jetton.amount,
+            // The jetton master is not carried in the wallet-to-wallet
+            // `internal_transfer`; a stateless template can't resolve it without
+            // an RPC call, so `token` is intentionally left undefined.
+            tokenType: 'TOKEN',
+            timestamp,
+            transactionHash,
+            transactionGasFee,
+          });
+          continue;
+        }
+
+        const inValue = BigInt(inMsg.value || '0');
+        if (inValue > 0n) {
+          transfers.push({
+            blockNumber,
+            from: inMsg.source?.account_address,
+            to,
+            amount: inValue,
+            token: 'TON',
+            tokenType: 'NATIVE',
+            timestamp,
+            transactionHash,
+            transactionGasFee,
+          });
         }
       }
     }
@@ -58,23 +125,46 @@ export const TONTokenTransfers: SubTemplate = {
 
   tests: [
     {
+      // Native TON transfer — `in_msg` carries value and no jetton body.
       params: {
         network: 'TON',
-        walletAddress: 'EQAFukUyzmHjUvOYDOjNE-wbZFFl2FWas1rFJoh8IiTsWD40',
-        contractAddress: '',
+        transactionHash: 'rwDRQeWniNdxBayFcDavE/Wo35B+MsfO4lJJmvz5Edk=',
       },
-      payload: 'https://jiti.indexing.co/networks/ton/44919328',
+      payload: 'https://jiti.indexing.co/networks/ton/71399000',
       output: [
         {
-          blockNumber: 44919328,
-          from: 'EQAFukUyzmHjUvOYDOjNE-wbZFFl2FWas1rFJoh8IiTsWD40',
-          to: 'EQCFTFAHOU3vFt2NiZhRD5dwuS0k7GS59vIg3WfCKwfaQGW2',
-          amount: 10000000n,
+          blockNumber: 71399000,
+          from: 'EQBkhlXTyZjri7SfyZcgFbRkjlLvq4kU3UjBTtiTtwLITn0H',
+          to: 'EQABGo8KCza3ea8DNHMnSWZmbRzW-05332eTdfvW-XDQEjQM',
+          amount: 203686310466n,
           token: 'TON',
           tokenType: 'NATIVE',
-          timestamp: '2025-02-13T23:10:18.000Z',
-          transactionHash: 'Vh5cWr2uvCsdhoouBQ+EiUcF54os9oqvh8A/62EroQc=',
-          transactionGasFee: 2355233n,
+          timestamp: '2026-06-05T15:31:47.000Z',
+          transactionHash: 'rwDRQeWniNdxBayFcDavE/Wo35B+MsfO4lJJmvz5Edk=',
+          transactionGasFee: 6668n,
+        },
+      ],
+    },
+    {
+      // Jetton transfer — `in_msg` is an internal_transfer (op 0x178d4519). The
+      // message also carries 49740664 nanoTON of forwarded gas, which must NOT
+      // surface as a phantom native transfer. `token` is left undefined (the
+      // jetton master is not in the wallet-to-wallet message).
+      params: {
+        network: 'TON',
+        transactionHash: 'Tx+nOxUzqo8kYpNkX20C2OTg6Dd9d6MHadQsknv4620=',
+      },
+      payload: 'https://jiti.indexing.co/networks/ton/71399000',
+      output: [
+        {
+          blockNumber: 71399000,
+          from: 'EQDshc_H_RAJNi5CG1oBQfUQ1lQBB6tz54Kf2h756Xp14_Cv',
+          to: 'EQBMzIc7YUB_WkSkmaIooZyONQDayNfipt3PQ4IJRsGXsPGI',
+          amount: 2800000000n,
+          tokenType: 'TOKEN',
+          timestamp: '2026-06-05T15:31:47.000Z',
+          transactionHash: 'Tx+nOxUzqo8kYpNkX20C2OTg6Dd9d6MHadQsknv4620=',
+          transactionGasFee: 233386n,
         },
       ],
     },


### PR DESCRIPTION
## What

Rewrites the TON token-transfers helper (`src/templates/token-transfers/ton.ts`) as a single `shards[].transactions[]` pass over each transaction's `in_msg`, adding **jetton** support and fixing three correctness issues. Adds `@ton/core` (`^0.63.1`, zero runtime deps) for BoC cell parsing.

## Changes

**1. Jetton transfers (new).** Decodes the inbound `internal_transfer` body (op `0x178d4519`) and emits `tokenType: 'TOKEN'` with the decoded amount, the recipient jetton wallet as `to`, and the sending owner as `from`. The jetton master is not carried in the wallet-to-wallet `internal_transfer`, so `token` is intentionally left `undefined` — a stateless template can't resolve it without an RPC call. (Happy to align on a different convention if you prefer.)

**2. Native and jetton are mutually exclusive per message.** A jetton `internal_transfer` also carries forwarded gas as `in_msg.value`; previously that surfaced as a phantom native transfer. Now a decoded jetton wins and no phantom native is emitted.

**3. `in_msg`-only walk (was `in_msg` + `out_msgs`).** Every transfer is recorded once, at the recipient's transaction, with `from` carried on the row so sender-side queries still match. The old `out_msgs` loop double-emitted every hop, since both the sender's and the recipient's transactions appear in range. Validated against live data: across 143 transactions in 4 blocks, **112/112** value-bearing `out_msgs` had their recipient transaction in the same block, so dropping the walk removes only duplicates.

**4. Per-transaction timestamp from `tx.utime`.** Replaces `shards[0].gen_utime`, which is wrong for any transaction outside the first shard and `undefined` for empty shards (yielding `Invalid Date`).

## Tests

`tests` updated to a native and a jetton transfer from block `71399000`. The jetton decode was cross-checked byte-for-byte against an independent BoC parser on several live transactions. Addresses are kept in user-friendly bounceable (`EQ…`) form, matching the existing helper convention.
