### PR TITLE
feat(cache): jiti-owned cache-or-lookup layer + TON jetton enrichment

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,13 @@
     "isomorphic-fetch": "^3.0.0",
     "tronweb": "^6.0.4",
     "viem": "^2.21.1"
+  },
+  "peerDependencies": {
+    "pg": ">=8"
+  },
+  "peerDependenciesMeta": {
+    "pg": {
+      "optional": true
+    }
   }
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,119 @@
+import { policyFor } from './registry';
+import { CacheStorage } from './types';
+
+export { registerCacheNamespace } from './registry';
+export type { CacheStorage, CacheRow, CacheResolver, NamespacePolicy, JettonWalletData } from './types';
+
+// cache-or-lookup core. jiti owns the orchestration — in-process L1, single-flight, negative
+// caching, TTL/immutability, read-through/write-through — and the per-namespace resolvers.
+// The consumer injects only durable storage (see createPostgresCacheStorage for a ready-made
+// Postgres adapter). With no storage available, callers simply don't invoke cacheGet.
+
+const L1_MAX = 50_000;
+type L1Entry = { value: unknown; expiresAt: number | null };
+const L1 = new Map<string, L1Entry>();
+
+function l1Get(id: string): L1Entry | undefined {
+  const e = L1.get(id);
+  if (!e) {
+    return undefined;
+  }
+  if (e.expiresAt !== null && e.expiresAt <= Date.now()) {
+    L1.delete(id);
+    return undefined;
+  }
+  L1.delete(id);
+  L1.set(id, e); // bump recency
+  return e;
+}
+
+function l1Set(id: string, value: unknown, expiresAt: number | null): void {
+  if (L1.size >= L1_MAX) {
+    const oldest = L1.keys().next().value as string | undefined;
+    if (oldest !== undefined) {
+      L1.delete(oldest);
+    }
+  }
+  L1.set(id, { value, expiresAt });
+}
+
+const inflight = new Map<string, Promise<unknown | null>>();
+
+function cacheId(namespace: string, key: string): string {
+  return `${namespace} ${key}`;
+}
+
+/**
+ * Read an enrichment value for (namespace, key) against the injected storage. On a miss, if
+ * the namespace has a registered resolver, resolve + write-through; otherwise return null
+ * (externally-populated namespaces). Returns null for negative hits; a resolver that throws
+ * (transient, e.g. RPC) is NOT cached so it retries next time.
+ */
+export async function cacheGet(storage: CacheStorage, namespace: string, key: string): Promise<unknown | null> {
+  const id = cacheId(namespace, key);
+
+  const l1 = l1Get(id);
+  if (l1) {
+    return l1.value;
+  }
+  const existing = inflight.get(id);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const p = (async (): Promise<unknown | null> => {
+    const row = await storage.get(namespace, key);
+    if (row && (row.expiresAt === null || row.expiresAt > Date.now())) {
+      const value = row.found ? row.value : null;
+      l1Set(id, value, row.expiresAt);
+      return value;
+    }
+
+    const policy = policyFor(namespace);
+    if (!policy.resolve) {
+      return null; // externally-populated namespace: miss ⇒ null (no write)
+    }
+
+    let resolved: unknown | null = null;
+    try {
+      resolved = await policy.resolve(key);
+    } catch {
+      // Transient resolver failure (e.g. RPC) — do NOT cache so it retries next time.
+      return null;
+    }
+
+    const found = resolved !== null && resolved !== undefined;
+    const negativeTtl = policy.negativeTtlSeconds ?? 3600;
+    if (!found && negativeTtl === 0) {
+      return null; // negative caching disabled for this namespace
+    }
+
+    const ttlSeconds = found ? policy.ttlSeconds : negativeTtl;
+    const expiresAt = ttlSeconds === null || ttlSeconds === undefined ? null : Date.now() + ttlSeconds * 1000;
+
+    await storage.set(namespace, key, { value: found ? resolved : null, found, expiresAt });
+    l1Set(id, found ? resolved : null, expiresAt);
+    return found ? resolved : null;
+  })().finally(() => inflight.delete(id));
+
+  inflight.set(id, p);
+  return p;
+}
+
+/**
+ * Write an enrichment value out-of-band (for externally-populated namespaces like token-price
+ * / wallet-label, or to pre-seed a row). TTL comes from the namespace policy unless overridden.
+ */
+export async function cacheSet(
+  storage: CacheStorage,
+  namespace: string,
+  key: string,
+  value: unknown,
+  ttlSecondsOverride?: number | null
+): Promise<void> {
+  const policy = policyFor(namespace);
+  const ttlSeconds = ttlSecondsOverride !== undefined ? ttlSecondsOverride : policy.ttlSeconds;
+  const expiresAt = ttlSeconds === null || ttlSeconds === undefined ? null : Date.now() + ttlSeconds * 1000;
+  await storage.set(namespace, key, { value, found: true, expiresAt });
+  l1Set(cacheId(namespace, key), value, expiresAt);
+}

--- a/src/cache/registry.ts
+++ b/src/cache/registry.ts
@@ -1,0 +1,16 @@
+import { NamespacePolicy } from './types';
+
+// Per-namespace policy registry. Namespaces differ only here: immutable vs TTL
+// (`ttlSeconds`), and resolve-on-miss vs externally-populated (presence of `resolve`).
+// jiti registers the namespaces it can resolve itself (e.g. ton-jetton-wallet); a consumer
+// may register its own (e.g. token-price with no resolver, populated via cacheSet).
+
+const REGISTRY = new Map<string, NamespacePolicy>();
+
+export function registerCacheNamespace(namespace: string, policy: NamespacePolicy): void {
+  REGISTRY.set(namespace, policy);
+}
+
+export function policyFor(namespace: string): NamespacePolicy {
+  return REGISTRY.get(namespace) ?? {};
+}

--- a/src/cache/resolvers/ton-jetton.ts
+++ b/src/cache/resolvers/ton-jetton.ts
@@ -1,0 +1,144 @@
+import { Address, Cell } from '@ton/core';
+
+import { cacheGet } from '../index';
+import { registerCacheNamespace } from '../registry';
+import { CacheStorage, JettonWalletData } from '../types';
+
+// Resolves a TON jetton wallet → { owner, master } via the standard `get_wallet_data`
+// get-method (TEP-74). The mapping is immutable, so it's cached forever. This is what lets
+// the token-transfers template enrich TON jetton transfers (jiti emits `to` = the jetton
+// wallet, `token` = undefined) into the real owner + master, at most one RPC per wallet ever.
+//
+// Fronted on the free, unthrottled Orbs TON Access gateway — the healthy node set is resolved
+// at runtime and rotated across on the intermittent liteserver timeouts they return. This is
+// the one place jiti performs network RPC, and only on the enrichment path.
+
+export const TON_JETTON_NAMESPACE = 'ton-jetton-wallet';
+
+const ORBS_MANAGER_URL = 'https://ton.access.orbs.network/mngr/nodes';
+const ORBS_REFRESH_MS = 5 * 60 * 1000;
+
+let orbsHosts: string[] = [];
+let orbsRefreshedAt = 0;
+
+type OrbsNode = { NodeId: string; Healthy: string; Mngr?: { health?: Record<string, boolean> } };
+
+function shuffled(hosts: string[]): string[] {
+  const a = [...hosts];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+async function getHosts(): Promise<string[]> {
+  if (orbsHosts.length && Date.now() - orbsRefreshedAt < ORBS_REFRESH_MS) {
+    return shuffled(orbsHosts);
+  }
+  try {
+    const resp = await fetch(ORBS_MANAGER_URL, { signal: AbortSignal.timeout(8000) });
+    const nodes = (await resp.json()) as OrbsNode[];
+    const healthy = nodes
+      .filter((n) => n.Healthy === '1' && n.Mngr?.health?.['v2-mainnet'])
+      .map((n) => `https://ton.access.orbs.network/${n.NodeId}/1/mainnet/toncenter-api-v2/jsonRPC`);
+    if (healthy.length) {
+      orbsHosts = healthy;
+      orbsRefreshedAt = Date.now();
+    }
+  } catch {
+    // keep prior cached set
+  }
+  return shuffled(orbsHosts);
+}
+
+// Canonicalize to jiti's emitted form (bounceable, url-safe, mainnet) so a TON address
+// compares equal to the one the token-transfer template emits. Input returned as-is if unparseable.
+export function normalizeTonAddress(addr: string): string {
+  try {
+    return Address.parse(addr).toString({ urlSafe: true, bounceable: true, testOnly: false });
+  } catch {
+    return addr;
+  }
+}
+
+function parseAddressFromStackEntry(entry: unknown): string | null {
+  // toncenter v2 runGetMethod returns slice/cell results as ['cell', { bytes: <base64 BoC> }].
+  const value = (entry as [string, { bytes?: string } | string])?.[1];
+  const b64 = typeof value === 'string' ? value : value?.bytes;
+  if (!b64) {
+    return null;
+  }
+  return normalizeTonAddress(Cell.fromBase64(b64).beginParse().loadAddress().toString());
+}
+
+async function runGetMethod(
+  host: string,
+  address: string,
+  method: string,
+  stack: unknown[]
+): Promise<{ exitCode: number; stack: unknown[] }> {
+  const resp = await fetch(host, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'runGetMethod', params: { address, method, stack } }),
+    signal: AbortSignal.timeout(15000),
+  });
+  const json = (await resp.json()) as { ok: boolean; error?: string; result?: { exit_code: number; stack: unknown[] } };
+  if (!json.ok || !json.result) {
+    throw new Error(`TON runGetMethod ${method} error: ${json.error || 'unknown'}`);
+  }
+  return { exitCode: json.result.exit_code, stack: json.result.stack };
+}
+
+/**
+ * Resolve a jetton wallet to its { owner, master }. Returns null if the account isn't a jetton
+ * wallet (definitive miss → negative-cached). Throws on transient RPC failure so the cache layer
+ * does NOT cache it (retries next time).
+ */
+export async function resolveJettonWalletData(wallet: string): Promise<JettonWalletData | null> {
+  const hosts = await getHosts();
+  if (!hosts.length) {
+    throw new Error('TON: no Orbs hosts available for get_wallet_data');
+  }
+
+  let sawDefiniteMiss = false;
+  let lastErr: Error | undefined;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    for (const host of hosts) {
+      try {
+        const { exitCode, stack } = await runGetMethod(host, wallet, 'get_wallet_data', []);
+        if (exitCode !== 0) {
+          sawDefiniteMiss = true; // no get_wallet_data → not a jetton wallet
+          continue;
+        }
+        const owner = parseAddressFromStackEntry(stack[1]);
+        const master = parseAddressFromStackEntry(stack[2]);
+        if (owner && master) {
+          return { owner, master };
+        }
+        sawDefiniteMiss = true;
+      } catch (e) {
+        lastErr = e as Error;
+      }
+    }
+  }
+
+  if (sawDefiniteMiss) {
+    return null; // definitive: not a jetton wallet → negative-cache
+  }
+  throw new Error(`TON: get_wallet_data failed for ${wallet}: ${lastErr?.message}`); // transient → don't cache
+}
+
+/** Enrich a TON jetton wallet (any address form) → { owner, master } via the cache. */
+export async function lookupJettonWallet(storage: CacheStorage, wallet: string): Promise<JettonWalletData | null> {
+  return (await cacheGet(storage, TON_JETTON_NAMESPACE, normalizeTonAddress(wallet))) as JettonWalletData | null;
+}
+
+// Register on import: immutable mapping, resolve-on-miss via get_wallet_data; non-jetton
+// accounts negative-cached for a day.
+registerCacheNamespace(TON_JETTON_NAMESPACE, {
+  resolve: (key) => resolveJettonWalletData(key),
+  ttlSeconds: null,
+  negativeTtlSeconds: 86400,
+});

--- a/src/cache/storage/postgres.ts
+++ b/src/cache/storage/postgres.ts
@@ -1,0 +1,96 @@
+import { CacheStorage } from '../types';
+
+// A ready-made Postgres CacheStorage. A jiti consumer (indexer, nbd) imports this, hands it a
+// connection URI, and injects the result back into the token-transfers template via
+// `_ctx.cacheStorage`. The `jiti_cache` table is created on first use.
+//
+// `pg` is an OPTIONAL peer dependency: it's lazy-required here so it never loads (or bundles)
+// for consumers that don't use this adapter — e.g. oscar's pacemaker, which only does sync
+// decode. Engines that use the cache (indexer, nbd) already depend on `pg`.
+
+type PgPool = {
+  query: (text: string, values?: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
+};
+
+export type PostgresCacheStorageOptions = {
+  connectionUri: string;
+  table?: string;
+  /** Provide your own pool/client (must have `.query(text, values)`) instead of a URI. */
+  pool?: PgPool;
+};
+
+export function createPostgresCacheStorage(opts: PostgresCacheStorageOptions): CacheStorage {
+  const table = (opts.table ?? 'jiti_cache').replace(/[^a-zA-Z0-9_]/g, '');
+
+  let pool = opts.pool;
+  function getPool(): PgPool {
+    if (!pool) {
+      // Obscure the require so jiti's bundler leaves `pg` external (loaded from the consumer).
+      const requirePg = eval('require') as (m: string) => {
+        Pool: new (cfg: { connectionString: string }) => PgPool;
+      };
+      const pg = requirePg('pg');
+      pool = new pg.Pool({ connectionString: opts.connectionUri });
+    }
+    return pool;
+  }
+
+  let ready: Promise<void> | undefined;
+  function ensureTable(): Promise<void> {
+    if (!ready) {
+      ready = (async () => {
+        const p = getPool();
+        await p.query(
+          `CREATE TABLE IF NOT EXISTS ${table} (
+             namespace   text        NOT NULL,
+             key         text        NOT NULL,
+             value       jsonb,
+             found       boolean     NOT NULL DEFAULT true,
+             resolved_at timestamptz NOT NULL DEFAULT now(),
+             expires_at  timestamptz,
+             PRIMARY KEY (namespace, key)
+           );`
+        );
+        await p.query(
+          `CREATE INDEX IF NOT EXISTS ${table}_expires_idx ON ${table} (expires_at) WHERE expires_at IS NOT NULL;`
+        );
+      })();
+    }
+    return ready;
+  }
+
+  return {
+    async get(namespace, key) {
+      await ensureTable();
+      const { rows } = await getPool().query(
+        `SELECT value, found, expires_at FROM ${table} WHERE namespace = $1 AND key = $2`,
+        [namespace, key]
+      );
+      if (!rows.length) {
+        return null;
+      }
+      const row = rows[0];
+      return {
+        value: row.value ?? null, // node-postgres parses jsonb → object
+        found: row.found as boolean,
+        expiresAt: row.expires_at ? new Date(row.expires_at as string).getTime() : null,
+      };
+    },
+    async set(namespace, key, row) {
+      await ensureTable();
+      await getPool().query(
+        `INSERT INTO ${table} (namespace, key, value, found, resolved_at, expires_at)
+         VALUES ($1, $2, $3::jsonb, $4, now(), $5)
+         ON CONFLICT (namespace, key) DO UPDATE
+           SET value = EXCLUDED.value, found = EXCLUDED.found, resolved_at = now(), expires_at = EXCLUDED.expires_at`,
+        [
+          namespace,
+          key,
+          row.value === null || row.value === undefined ? null : JSON.stringify(row.value),
+          row.found,
+          row.expiresAt ? new Date(row.expiresAt).toISOString() : null,
+        ]
+      );
+    },
+  };
+}

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -1,0 +1,30 @@
+// A generic "cache-or-lookup" enrichment layer for jiti templates. jiti owns the cache
+// orchestration (in-process L1, single-flight, negative caching, TTL/immutability) AND the
+// per-namespace resolvers (e.g. the TON jetton get_wallet_data RPC). The ONLY thing a
+// consumer injects is durable storage — a thin key/value adapter (Postgres in the indexer,
+// the same contract in NBD). jiti has no DB dependency; the engine owns the connection.
+
+export type CacheRow = {
+  value: unknown | null;
+  found: boolean;
+  expiresAt: number | null; // epoch ms; null = immutable / never expires
+};
+
+// Durable L2 store, injected by the consumer. A dumb key/value adapter — jiti owns expiry
+// and negative-cache semantics, so `get` returns whatever was stored (jiti decides validity).
+export type CacheStorage = {
+  get: (namespace: string, key: string) => Promise<CacheRow | null>;
+  set: (namespace: string, key: string, row: CacheRow) => Promise<void>;
+};
+
+// Resolves a miss for a namespace. Returns the value, or null for a definitive miss
+// (negative-cached). Throw on a transient failure (e.g. RPC) so it is NOT cached and retries.
+export type CacheResolver = (key: string) => Promise<unknown | null>;
+
+export type NamespacePolicy = {
+  resolve?: CacheResolver; // absent ⇒ externally-populated (miss ⇒ null, no write)
+  ttlSeconds?: number | null; // null/undefined ⇒ immutable
+  negativeTtlSeconds?: number; // default 3600; 0 ⇒ don't cache misses
+};
+
+export type JettonWalletData = { owner: string; master: string };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,12 @@ export type { NetworkTransfer } from './templates/token-transfers/types';
 export const utils = { ...allUtils };
 export const templates = { ...allTemplates };
 
+// cache-or-lookup enrichment layer (jiti owns the cache + resolvers; consumer injects storage)
+export { cacheGet, cacheSet, registerCacheNamespace } from './cache';
+export { createPostgresCacheStorage } from './cache/storage/postgres';
+export { lookupJettonWallet, resolveJettonWalletData, TON_JETTON_NAMESPACE } from './cache/resolvers/ton-jetton';
+export type { CacheStorage, CacheRow, CacheResolver, NamespacePolicy, JettonWalletData } from './cache/types';
+
 export function getAllTemplates() {
   return Object.values(allTemplates).slice();
 }

--- a/src/templates/token-transfers/index.ts
+++ b/src/templates/token-transfers/index.ts
@@ -6,6 +6,8 @@ import { CosmosTokenTransfers } from './cosmos';
 import { EVMTokenTransfers } from './evm';
 import { FilecoinTokenTransfers } from './filecoin';
 import { NetworkTransfer } from './types';
+import { CacheStorage } from '../../cache/types';
+import { lookupJettonWallet } from '../../cache/resolvers/ton-jetton';
 import { RippleTokenTransfers } from './ripple';
 import { SUITokenTransfers } from './sui';
 import { SVMTokenTransfers } from './svm';
@@ -30,6 +32,43 @@ const SUB_TEMPLATES = [
 ];
 
 const UNIVERSAL_SUB_TEMPLATES = [CosmosTokenTransfers, EVMTokenTransfers];
+
+// Drops zero-amount + duplicate transfers and applies the optional contractAddress /
+// walletAddress / transactionHash param filters. Runs AFTER any jetton enrichment so the
+// filters see the resolved owner/master.
+function applyTransferFilters(
+  transfers: NetworkTransfer[],
+  _ctx?: Record<string, unknown> & { params: Record<string, unknown> }
+): NetworkTransfer[] {
+  const seenTransfers = new Set<string>();
+
+  return transfers.filter((txfer) => {
+    if (txfer.amount <= BigInt(0)) {
+      return false;
+    }
+    if (_ctx?.params) {
+      if (_ctx.params.contractAddress && _ctx.params.contractAddress !== txfer.token) {
+        return false;
+      }
+      if (_ctx.params.walletAddress && ![txfer.from, txfer.to].includes(_ctx.params.walletAddress as string)) {
+        return false;
+      }
+      if (_ctx.params.transactionHash && txfer.transactionHash !== _ctx.params.transactionHash) {
+        return false;
+      }
+    }
+
+    const key = `${txfer.transactionHash}-${txfer.from}-${txfer.to}-${txfer.amount}-${txfer.token}-${txfer.index}`;
+
+    if (seenTransfers.has(key)) {
+      return false;
+    }
+
+    seenTransfers.add(key);
+
+    return true;
+  });
+}
 
 const tokenTransfersTemplate: Template = {
   key: 'token_transfers',
@@ -61,36 +100,34 @@ const tokenTransfersTemplate: Template = {
       }
     }
 
-    const seenTransfers = new Set<string>();
+    // Optional enrichment for account-model token transfers (TON jettons) where the block
+    // only carries the token-WALLET address and no master: they come out as
+    // `tokenType: 'TOKEN'`, `to` = wallet, `token` = undefined. When the caller injects a
+    // `_ctx.cacheStorage` (durable cache), jiti resolves the wallet → { owner, master } via
+    // its own cache+RPC and rewrites `to`/`token` BEFORE filtering, so contractAddress /
+    // walletAddress filters match the real owner + master. jiti owns the cache + resolver
+    // (get_wallet_data over Orbs); the consumer injects only storage. Async only when storage
+    // is provided; the sync path is unchanged for every existing caller.
+    const cacheStorage = _ctx?.cacheStorage as CacheStorage | undefined;
+    if (cacheStorage) {
+      return (async () => {
+        await Promise.all(
+          transfers.map(async (txfer) => {
+            if (txfer.tokenType !== 'TOKEN' || txfer.token || !txfer.to) {
+              return;
+            }
+            const info = await lookupJettonWallet(cacheStorage, txfer.to);
+            if (info) {
+              txfer.to = info.owner;
+              txfer.token = info.master;
+            }
+          })
+        );
+        return applyTransferFilters(transfers, _ctx);
+      })();
+    }
 
-    transfers = transfers.filter((txfer) => {
-      if (txfer.amount <= BigInt(0)) {
-        return false;
-      }
-      if (_ctx?.params) {
-        if (_ctx.params.contractAddress && _ctx.params.contractAddress !== txfer.token) {
-          return false;
-        }
-        if (_ctx.params.walletAddress && ![txfer.from, txfer.to].includes(_ctx.params.walletAddress as string)) {
-          return false;
-        }
-        if (_ctx.params.transactionHash && txfer.transactionHash !== _ctx.params.transactionHash) {
-          return false;
-        }
-      }
-
-      const key = `${txfer.transactionHash}-${txfer.from}-${txfer.to}-${txfer.amount}-${txfer.token}-${txfer.index}`;
-
-      if (seenTransfers.has(key)) {
-        return false;
-      }
-
-      seenTransfers.add(key);
-
-      return true;
-    });
-
-    return transfers;
+    return applyTransferFilters(transfers, _ctx);
   },
 
   tests: SUB_TEMPLATES.concat(UNIVERSAL_SUB_TEMPLATES)


### PR DESCRIPTION
Moves the **entire cache-or-lookup enrichment layer into jiti** (per direction): jiti owns the cache orchestration *and* the resolvers *and* the resolver RPC. A consumer injects **only durable storage** — and jiti ships a ready-made Postgres adapter so the consumer just hands it a URI.

## What jiti now owns (`src/cache/`)
- **Core** (`index.ts`): `cacheGet` / `cacheSet` — in-process L1, single-flight, negative caching, TTL/immutability, read-through/write-through. Generic + multi-namespace.
- **Registry** (`registry.ts`): per-namespace policy (resolver, TTL, negative-TTL).
- **`CacheStorage` interface** (`types.ts`): the only thing a consumer implements.
- **TON jetton resolver** (`resolvers/ton-jetton.ts`): wallet → `{owner, master}` via `get_wallet_data` (TEP-74) over the free Orbs gateway with host rotation; registers the immutable `ton-jetton-wallet` namespace. **The one place jiti does network RPC**, only on the enrichment path.
- **Ready-made PG adapter** (`storage/postgres.ts`): `createPostgresCacheStorage({ connectionUri })` — indexer/nbd import it, pass a URI, inject. The `jiti_cache` table self-creates. `pg` is an **optional peer dependency**, lazy-required so it never bundles/loads for consumers that don't use the cache (e.g. oscar's pacemaker) — verified not in the parcel bundle.

## token-transfers
Enriches TON jetton transfers (`tokenType:'TOKEN'`, `to` = wallet, `token` undefined) → `to = owner`, `token = master`, **before** the contractAddress/walletAddress filters — but only when `_ctx.cacheStorage` is injected. **Opt-in / non-breaking:** no storage → `transform` is sync and byte-identical to today; existing callers (oscar pacemaker, etc.) unaffected.

## Consumer side (follow-up, indexer)
Indexer drops its own jiti-cache + resolver and shrinks to: `import { createPostgresCacheStorage } from '@indexing/jiti'`, pass the recent-DB URI (gated by `JITI_CACHE_DB_URI`), inject as `_ctx.cacheStorage`. NBD does the same at migration.

## Notes
- Build clean (parcel); cache API + `createPostgresCacheStorage` in `dist/types.d.ts`; `pg` externalized.
- `npm test` (fetches real blocks, needs `API_KEY`) not run locally — sync path unchanged, existing template tests unaffected.
- The `eval`-require targets CommonJS consumers (indexer/nbd are CJS).
