### PR TITLE
feat(cache): injectable TON RPC hosts for the jetton resolver (setTonRpcHosts)

### DIFF
--- a/src/cache/resolvers/ton-jetton.ts
+++ b/src/cache/resolvers/ton-jetton.ts
@@ -21,6 +21,16 @@ const ORBS_REFRESH_MS = 5 * 60 * 1000;
 let orbsHosts: string[] = [];
 let orbsRefreshedAt = 0;
 
+// Consumer-injected TON RPC hosts (toncenter v2 jsonRPC-compatible base hosts). When set, the
+// resolver uses THESE instead of Orbs discovery — e.g. the indexer injects oscar's configured
+// TON hosts (BlockPi/QuickNode from network_connections) so jiti hits the same hosts oscar uses
+// and avoids Orbs's per-IP rate limit on the oscar box. Empty ⇒ fall back to Orbs discovery.
+let configuredHosts: string[] = [];
+
+export function setTonRpcHosts(hosts: string[]): void {
+  configuredHosts = (hosts || []).filter(Boolean);
+}
+
 type OrbsNode = { NodeId: string; Healthy: string; Mngr?: { health?: Record<string, boolean> } };
 
 function shuffled(hosts: string[]): string[] {
@@ -32,7 +42,16 @@ function shuffled(hosts: string[]): string[] {
   return a;
 }
 
+// toncenter v2 speaks JSON-RPC at `<host>/jsonRPC`. Orbs hosts already end in it; BlockPi-style
+// base hosts (…/rpc/<key>) need it appended — mirrors oscar's TON buildUrl.
+function buildUrl(host: string): string {
+  return host.endsWith('/jsonRPC') ? host : `${host.replace(/\/$/, '')}/jsonRPC`;
+}
+
 async function getHosts(): Promise<string[]> {
+  if (configuredHosts.length) {
+    return shuffled(configuredHosts).map(buildUrl);
+  }
   if (orbsHosts.length && Date.now() - orbsRefreshedAt < ORBS_REFRESH_MS) {
     return shuffled(orbsHosts);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,12 @@ export const templates = { ...allTemplates };
 // cache-or-lookup enrichment layer (jiti owns the cache + resolvers; consumer injects storage)
 export { cacheGet, cacheSet, registerCacheNamespace } from './cache';
 export { createPostgresCacheStorage } from './cache/storage/postgres';
-export { lookupJettonWallet, resolveJettonWalletData, TON_JETTON_NAMESPACE } from './cache/resolvers/ton-jetton';
+export {
+  lookupJettonWallet,
+  resolveJettonWalletData,
+  setTonRpcHosts,
+  TON_JETTON_NAMESPACE,
+} from './cache/resolvers/ton-jetton';
 export type { CacheStorage, CacheRow, CacheResolver, NamespacePolicy, JettonWalletData } from './cache/types';
 
 export function getAllTemplates() {


### PR DESCRIPTION
The TON jetton resolver hardcoded the Orbs gateway. Orbs rate-limits per IP (HTTP 429), and the indexer/oscar box already saturates Orbs from its TON pacemaker — so jiti's resolver got 429s there, never resolved, and the cache stayed empty (graceful fallback, no regression, but no enrichment). Caught by the oscar-queuer canary rollout.

## Change
- `setTonRpcHosts(hosts: string[])` — consumer injects TON RPC hosts; `getHosts()` uses them (with the `…/jsonRPC` buildUrl + shuffle/rotation oscar uses) when set, else falls back to Orbs discovery. Exported from the entry.
- No behavior change for callers that don't set hosts (still Orbs).

## Consumer (indexer, follow-up)
At boot, read oscar's TON hosts from `network_connections` and call `setTonRpcHosts(...)` so jiti hits the same paid hosts oscar does — which the box reaches without the Orbs 429.

tsc + parcel build clean.