### PR TITLE
refactor(cache): generic per-network setRpcHosts (replaces setTonRpcHosts)

### DIFF
--- a/src/cache/resolvers/ton-jetton.ts
+++ b/src/cache/resolvers/ton-jetton.ts
@@ -2,6 +2,7 @@ import { Address, Cell } from '@ton/core';
 
 import { cacheGet } from '../index';
 import { registerCacheNamespace } from '../registry';
+import { getRpcHosts } from '../rpc-hosts';
 import { CacheStorage, JettonWalletData } from '../types';
 
 // Resolves a TON jetton wallet → { owner, master } via the standard `get_wallet_data`
@@ -21,16 +22,6 @@ const ORBS_REFRESH_MS = 5 * 60 * 1000;
 let orbsHosts: string[] = [];
 let orbsRefreshedAt = 0;
 
-// Consumer-injected TON RPC hosts (toncenter v2 jsonRPC-compatible base hosts). When set, the
-// resolver uses THESE instead of Orbs discovery — e.g. the indexer injects oscar's configured
-// TON hosts (BlockPi/QuickNode from network_connections) so jiti hits the same hosts oscar uses
-// and avoids Orbs's per-IP rate limit on the oscar box. Empty ⇒ fall back to Orbs discovery.
-let configuredHosts: string[] = [];
-
-export function setTonRpcHosts(hosts: string[]): void {
-  configuredHosts = (hosts || []).filter(Boolean);
-}
-
 type OrbsNode = { NodeId: string; Healthy: string; Mngr?: { health?: Record<string, boolean> } };
 
 function shuffled(hosts: string[]): string[] {
@@ -49,8 +40,9 @@ function buildUrl(host: string): string {
 }
 
 async function getHosts(): Promise<string[]> {
-  if (configuredHosts.length) {
-    return shuffled(configuredHosts).map(buildUrl);
+  const configured = getRpcHosts('TON');
+  if (configured.length) {
+    return shuffled(configured).map(buildUrl);
   }
   if (orbsHosts.length && Date.now() - orbsRefreshedAt < ORBS_REFRESH_MS) {
     return shuffled(orbsHosts);

--- a/src/cache/rpc-hosts.ts
+++ b/src/cache/rpc-hosts.ts
@@ -1,0 +1,15 @@
+// Per-network RPC host registry. A jiti consumer injects the hosts a resolver should use for a
+// given chain — e.g. the indexer points the TON jetton resolver at the same hosts oscar uses
+// (BlockPi/QuickNode from network_connections) so jiti avoids Orbs's per-IP rate limit on the
+// oscar box. Generic so future resolvers (other chains) reuse it. Empty for a network ⇒ the
+// resolver falls back to its built-in default (e.g. Orbs discovery for TON).
+
+const rpcHostsByNetwork = new Map<string, string[]>();
+
+export function setRpcHosts(network: string, hosts: string[]): void {
+  rpcHostsByNetwork.set(network.toUpperCase(), (hosts || []).filter(Boolean));
+}
+
+export function getRpcHosts(network: string): string[] {
+  return rpcHostsByNetwork.get(network.toUpperCase()) ?? [];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,8 @@ export const templates = { ...allTemplates };
 // cache-or-lookup enrichment layer (jiti owns the cache + resolvers; consumer injects storage)
 export { cacheGet, cacheSet, registerCacheNamespace } from './cache';
 export { createPostgresCacheStorage } from './cache/storage/postgres';
-export {
-  lookupJettonWallet,
-  resolveJettonWalletData,
-  setTonRpcHosts,
-  TON_JETTON_NAMESPACE,
-} from './cache/resolvers/ton-jetton';
+export { lookupJettonWallet, resolveJettonWalletData, TON_JETTON_NAMESPACE } from './cache/resolvers/ton-jetton';
+export { setRpcHosts, getRpcHosts } from './cache/rpc-hosts';
 export type { CacheStorage, CacheRow, CacheResolver, NamespacePolicy, JettonWalletData } from './cache/types';
 
 export function getAllTemplates() {


### PR DESCRIPTION
Generalizes the injected-RPC-hosts config to be per-network (`setRpcHosts(network, hosts)` / `getRpcHosts(network)`), so any resolver can use it — not just TON. The TON jetton resolver now reads `getRpcHosts('TON')`, falling back to Orbs discovery when none set. Replaces the TON-only `setTonRpcHosts` from 0.1.15 (no consumers yet, so clean rename). tsc + build clean.