### PR TITLE
fix(evm): fall back to tx.gasPrice when receipt omits effectiveGasPrice (Cronos)

### DIFF
--- a/src/templates/token-transfers/evm.ts
+++ b/src/templates/token-transfers/evm.ts
@@ -24,7 +24,10 @@ export const EVMTokenTransfers: SubTemplate = {
       }
 
       const timestamp = new Date(typedBlock.timestamp * 1000).toISOString();
-      const transactionGasFee = BigInt(tx.receipt.gasUsed) * BigInt(tx.receipt.effectiveGasPrice);
+      // Some EVM forks (e.g. Cronos / Ethermint) omit effectiveGasPrice on the receipt;
+      // fall back to the tx's gasPrice so gas-fee math doesn't throw and drop the whole block.
+      const effectiveGasPrice = tx.receipt.effectiveGasPrice ?? tx.gasPrice ?? 0;
+      const transactionGasFee = BigInt(tx.receipt.gasUsed ?? 0) * BigInt(effectiveGasPrice);
 
       // check if this tx has zkSync native ETH Transfer logs (used to skip unreliable traces)
       const hasZkSyncEthLogs = tx.receipt.logs.some(


### PR DESCRIPTION
## Problem

Mesh reported missing data on their Cronos Mainnet dev pipeline — chains served by Alchemy/QuickNode worked, Cronos produced nothing.

Root cause is in the EVM token-transfer extractor. Cronos (an Ethermint/Cosmos-EVM fork) returns transaction **receipts without an `effectiveGasPrice` field**. The extractor does:

```js
const transactionGasFee = BigInt(tx.receipt.gasUsed) * BigInt(tx.receipt.effectiveGasPrice);
```

`BigInt(undefined)` **throws**, and since the throw propagates up through `tokenTransfers()`, it drops the **entire block** — every Cronos block containing transactions yields zero rows. That's the "missing data," and it's exactly why Alchemy/QuickNode chains were unaffected (they populate `effectiveGasPrice`).

## Fix

Fall back to the transaction's `gasPrice` (then `0`) so the gas-fee math can't throw:

```js
const effectiveGasPrice = tx.receipt.effectiveGasPrice ?? tx.gasPrice ?? 0;
const transactionGasFee = BigInt(tx.receipt.gasUsed ?? 0) * BigInt(effectiveGasPrice);
```

Backward-compatible — the fallback only triggers when `effectiveGasPrice` is absent (which previously threw), so no behavior change for any chain that already works. Likely also fixes other Ethermint-style chains (Evmos/Kava/Canto/etc.).

## Verification

Ran the customer's transform verbatim against live Cronos blocks via `jiti.indexing.co`:

- **Before:** `TypeError: Cannot convert undefined to a BigInt` at `evm.ts:27` → 0 rows
- **After:** 11 transfer rows extracted from a single Cronos block (correct amounts, hashes, indices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
